### PR TITLE
Add result to salsa api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,6 @@ source "http://rubygems.org"
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do
-  gem "shoulda", ">= 0"
   gem "rdoc", "~> 3.12"
-  gem "bundler", "~> 1.0.0"
   gem "jeweler", "~> 1.8.3"
-  gem "rcov", ">= 0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,3 @@
-source "http://rubygems.org"
-# Add dependencies required to use your gem here.
-# Example:
-#   gem "activesupport", ">= 2.3.5"
+source "https://rubygems.org"
 
-# Add dependencies to develop your gem here.
-# Include everything needed to run rake, tests, features, etc.
-group :development do
-  gem "rdoc", "~> 3.12"
-  gem "jeweler", "~> 1.8.3"
-end
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -17,8 +17,8 @@ Jeweler::Tasks.new do |gem|
   gem.name = "wired_for_change"
   gem.homepage = "http://github.com/actblue/wired_for_change"
   gem.license = "MIT"
-  gem.summary = %Q{TODO: one-line summary of your gem}
-  gem.description = %Q{TODO: longer description of your gem}
+  gem.summary = "Track donors through Salsa Labs"
+  gem.description = "Track donors through Salsa Labs using this Gem"
   gem.email = "contact@actblue.com"
   gem.authors = ["Bill Kirtley", "Akshat Pradhan"]
   # dependencies defined in Gemfile

--- a/Rakefile
+++ b/Rakefile
@@ -28,16 +28,8 @@ Jeweler::RubygemsDotOrgTasks.new
 require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
-  test.pattern = 'test/**/test_*.rb'
+  test.pattern = 'test/**_test.rb'
   test.verbose = true
-end
-
-require 'rcov/rcovtask'
-Rcov::RcovTask.new do |test|
-  test.libs << 'test'
-  test.pattern = 'test/**/test_*.rb'
-  test.verbose = true
-  test.rcov_opts << '--exclude "gems/*"'
 end
 
 task :default => :test

--- a/lib/wired_for_change/salsa_donation.rb
+++ b/lib/wired_for_change/salsa_donation.rb
@@ -1,7 +1,7 @@
 class SalsaDonation < SalsaObject
   salsa_attribute :Email, :First_Name, :Last_Name, :Occupation
   salsa_attribute :amount, :Transaction_Date, :Transaction_Type, :Form_Of_Payment
-  salsa_attribute :Order_Info, :Status
+  salsa_attribute :Order_Info, :Status, :RESULT
   salsa_attribute :Tracking_Code, :Donation_Tracking_Code
   salsa_attribute :Employer, :Employer_Street, :Employer_Street_2
   salsa_attribute :Employer_City, :Employer_State, :Employer_Zip

--- a/test/wired_for_change_test.rb
+++ b/test/wired_for_change_test.rb
@@ -1,3 +1,4 @@
+# TODO: rewrite these tests using latest minitest
 # Maybe someday this'll warrant a test_helper.rb
 # require File.join(File.dirname(__FILE__), 'test_helper')
 # in the mean time:<-END_TEST_HELPER

--- a/wired_for_change.gemspec
+++ b/wired_for_change.gemspec
@@ -1,6 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = "wired_for_change"
   s.version     = "0.0.2"
+  s.licenses    = ['MIT']
   s.author      = "Akshat Pradhan"
   s.email       = "contact@actblue.com"
   s.homepage    = "http://github.com/actblue/wired_for_change"
@@ -8,4 +9,6 @@ Gem::Specification.new do |s|
   s.description = "Track donors through Salsa Labs using this Gem"
   s.files        = Dir["lib/**/*", "[A-Z]*"] - ["Gemfile.lock"]
   s.require_path = "lib"
+  s.add_development_dependency "rdoc", "~> 3.12"
+  s.add_development_dependency "jeweler", "~> 1.8.3"
 end

--- a/wired_for_change.gemspec
+++ b/wired_for_change.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "wired_for_change"
-  s.version     = "0.0.1"
+  s.version     = "0.0.2"
   s.author      = "Akshat Pradhan"
   s.email       = "contact@actblue.com"
   s.homepage    = "http://github.com/actblue/wired_for_change"


### PR DESCRIPTION
The only changed needed for issue 4278 is adding RESULT as a salsa attribute. The rest is cleaning up the Gemfile/gemspec, and making sure the tests are actually invoked. However, the current tests will fail. They are out of date. Whether or not to fix them depends on what we decide to do with this gem.

Would it be better to remove the tests altogether?