### PR TITLE
Update for ruby 3

### DIFF
--- a/lib/wired_for_change/salsa_base.rb
+++ b/lib/wired_for_change/salsa_base.rb
@@ -2,7 +2,9 @@ require 'net/http'
 
 module UriEncoder
   def escape(v)
-    URI.escape(v.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+    # URI.escape(v.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+    p = URI::Parser.new
+    p.escape(v.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
   end
 
   def uri_encode(params)

--- a/lib/wired_for_change/salsa_base.rb
+++ b/lib/wired_for_change/salsa_base.rb
@@ -2,7 +2,6 @@ require 'net/http'
 
 module UriEncoder
   def escape(v)
-    # URI.escape(v.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
     p = URI::Parser.new
     p.escape(v.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
   end

--- a/lib/wired_for_change/version.rb
+++ b/lib/wired_for_change/version.rb
@@ -1,3 +1,3 @@
 module WiredForChange
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
In preparation for upgrading Indigo to Ruby 3, we need to update our wired_for_change gem. 
ActBlue’s wired_for_change gem is calling URI.escape, which we'll need to update to upgrade to Ruby 3 (because URI.escape is removed in Ruby 3)